### PR TITLE
Fix a signed/unsigned comparision issue.

### DIFF
--- a/archive_reader_entry_buffer.cpp
+++ b/archive_reader_entry_buffer.cpp
@@ -43,7 +43,7 @@ int entry_buffer::underflow()
 {
   if(gptr() == egptr())
   {
-    size_t _buff_size = archive_read_data(_archive, _buff, _buff_max_size);
+    ssize_t _buff_size = archive_read_data(_archive, _buff, _buff_max_size);
 
     if( _buff_size < 0 )
     {


### PR DESCRIPTION
ssize_t needs to be used, otherwise the comparasion _buff_size < 0 can never be true.
and as archive_read_data returns ssize_t a error could not be detected.